### PR TITLE
Fix dependencies and compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _build
+_opam
 *.install

--- a/blink.opam
+++ b/blink.opam
@@ -11,8 +11,8 @@ bug-reports: "https://github.com/leostera/blink/issues"
 depends: [
   "angstrom" {>= "0.15.0"}
   "castore" {>= "0.0.2"}
-  "bitstring"
   "digestif"
+  "bitstring"
   "httpaf"
   "ppx_bitstring"
   "faraday" {>= "0.8.2"}

--- a/blink.opam
+++ b/blink.opam
@@ -9,10 +9,12 @@ tags: ["http" "client" "http client" "riot" "multicore"]
 homepage: "https://github.com/leostera/blink"
 bug-reports: "https://github.com/leostera/blink/issues"
 depends: [
-  "trail" {>= "0.0.1"}
   "angstrom" {>= "0.15.0"}
   "castore" {>= "0.0.2"}
-  "httpaf" {>= "5.3.1"}
+  "bitstring"
+  "digestif"
+  "httpaf"
+  "ppx_bitstring"
   "faraday" {>= "0.8.2"}
   "http" {>= "6.0.0~alpha2"}
   "mdx" {with-test & >= "2.3.1"}

--- a/blink/blink.ml
+++ b/blink/blink.ml
@@ -8,6 +8,7 @@ module Connection = Connection
 module Protocol = Protocol
 module Transport = Transport
 module WebSocket = Websocket
+module Frame = Frame
 
 let pp_messages = Msg.pp_messages
 

--- a/blink/blink.mli
+++ b/blink/blink.mli
@@ -3,6 +3,7 @@
 *)
 
 open Riot
+module Frame = Frame
 
 (** {2 Connection}
 
@@ -47,8 +48,6 @@ val stream :
   IO.io_result
 
 module WebSocket : sig
-  open Trail
-
   type t
 
   val upgrade :

--- a/blink/dune
+++ b/blink/dune
@@ -5,12 +5,11 @@
   (pps bytestring.ppx ppx_bitstring))
  (libraries
   riot
-  trail
   http
+  bitstring
   httpaf
   uri
   castore
-  cohttp
   digestif
   faraday
   angstrom

--- a/blink/frame.ml
+++ b/blink/frame.ml
@@ -1,0 +1,313 @@
+open Riot
+
+open Logger.Make (struct
+  let namespace = [ "trail"; "ws"; "frame" ]
+end)
+
+(**
+    0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-------+-+-------------+-------------------------------+
+    |F|R|R|R| opcode|M| Payload len |    Extended payload length    |
+    |I|S|S|S|  (4)  |A|     (7)     |             (16/64)           |
+    |N|V|V|V|       |S|             |   (if payload len==126/127)   |
+    | |1|2|3|       |K|             |                               |
+    +-+-+-+-+-------+-+-------------+ - - - - - - - - - - - - - - - +
+    |     Extended payload length continued, if payload len == 127  |
+    + - - - - - - - - - - - - - - - +-------------------------------+
+    |                               |Masking-key, if MASK set to 1  |
+    +-------------------------------+-------------------------------+
+    | Masking-key (continued)       |          Payload Data         |
+    +-------------------------------- - - - - - - - - - - - - - - - +
+    :                     Payload Data continued ...                :
+    + - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +
+    |                     Payload Data continued ...                |
+    +---------------------------------------------------------------+
+
+    from: https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
+*)
+
+type t =
+  | Continuation of { fin : bool; compressed : bool; payload : string }
+  | Text of { fin : bool; compressed : bool; payload : string }
+  | Binary of { fin : bool; compressed : bool; payload : string }
+  | Connection_close of { fin : bool; compressed : bool; payload : string }
+  | Ping
+  | Pong
+
+let equal (a : t) (b : t) =
+  match (a, b) with
+  | ( Continuation { fin = fin1; compressed = compressed1; payload = payload1 },
+      Continuation { fin = fin2; compressed = compressed2; payload = payload2 }
+    ) ->
+      fin1 = fin2 && compressed1 = compressed2 && String.equal payload1 payload2
+  | ( Text { fin = fin1; compressed = compressed1; payload = payload1 },
+      Text { fin = fin2; compressed = compressed2; payload = payload2 } ) ->
+      fin1 = fin2 && compressed1 = compressed2 && String.equal payload1 payload2
+  | ( Binary { fin = fin1; compressed = compressed1; payload = payload1 },
+      Binary { fin = fin2; compressed = compressed2; payload = payload2 } ) ->
+      fin1 = fin2 && compressed1 = compressed2 && String.equal payload1 payload2
+  | ( Connection_close
+        { fin = fin1; compressed = compressed1; payload = payload1 },
+      Connection_close
+        { fin = fin2; compressed = compressed2; payload = payload2 } ) ->
+      fin1 = fin2 && compressed1 = compressed2 && String.equal payload1 payload2
+  | Ping, Ping | Pong, Pong -> true
+  | _ -> false
+
+let text ?(fin = false) ?(compressed = false) payload =
+  Text { fin; compressed; payload }
+
+let binary ?(fin = false) ?(compressed = false) payload =
+  Binary { fin; compressed; payload }
+
+let continuation ?(fin = false) ?(compressed = false) payload =
+  Continuation { fin; compressed; payload }
+
+let connection_close ?(fin = false) ?(compressed = false) payload =
+  Connection_close { fin; compressed; payload }
+
+let ping = Ping
+let pong = Pong
+
+let pp fmt (t : t) =
+  match t with
+  | Continuation { fin; compressed; payload } ->
+      Format.fprintf fmt "frame.continuation(%b,%b,%S)" fin compressed payload
+  | Text { fin; compressed; payload } ->
+      Format.fprintf fmt "frame.text(%b,%b,%S)" fin compressed payload
+  | Binary { fin; compressed; payload } ->
+      Format.fprintf fmt "frame.binary(%b,%b,%S)" fin compressed payload
+  | Connection_close { fin; compressed; payload } ->
+      Format.fprintf fmt "frame.connection_close(%b,%b,%S)" fin compressed
+        payload
+  | Ping -> Format.fprintf fmt "frame.ping"
+  | Pong -> Format.fprintf fmt "frame.pong"
+
+(* this function was copied from https://github.com/anmonteiro/websocketaf/blob/fork/lib/websocket.ml#L170-L176 *)
+let unmask mask payload =
+  let len = String.length payload in
+  let bs = Bigstringaf.of_string ~off:0 ~len payload in
+  for i = 0 to len - 1 do
+    let j = i mod 4 in
+    let c = Bigstringaf.unsafe_get bs i |> Char.code in
+    let c =
+      c lxor Int32.(logand (shift_right mask (8 * (3 - j))) 0xffl |> to_int)
+    in
+    Bigstringaf.unsafe_set bs i (Char.unsafe_chr c)
+  done;
+  Bigstringaf.to_string bs
+
+let new_mask () = Crypto.Random.int32 ()
+
+let make ~masked ~fin ~compressed ~rsv:_ ~opcode ~mask ~payload =
+  let payload = if masked then unmask mask payload else payload in
+
+  match opcode with
+  | 0x0 -> `ok (Continuation { fin; compressed; payload })
+  | 0x1 -> `ok (Text { fin; compressed; payload })
+  | 0x2 -> `ok (Binary { fin; compressed; payload })
+  | 0x8 -> `ok (Connection_close { fin; compressed; payload })
+  | 0x9 -> `ok Ping
+  | 0xA -> `ok Pong
+  | _ -> `error (`Unknown_opcode opcode)
+
+module Request = struct
+  let deserialize ?(max_frame_size = 0) data =
+    let binstr = Bitstring.bitstring_of_string data in
+    match%bitstring binstr with
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check( masked = true );
+       pad2 : 7 : check( pad2 = 127 );
+       length : 64;
+       mask : 32;
+       payload : Int64.(mul length 8L |> to_int) : string;
+       rest : -1 : bitstring |}
+      when max_frame_size = 0 || Int64.(length <= of_int max_frame_size) ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check( masked = true );
+       pad2 : 7 : check( pad2 = 126 );
+       length : 16 : int;
+       mask : 32 : int;
+       payload : (length * 8) : string;
+       rest : -1 : bitstring |}
+      when max_frame_size = 0 || length <= max_frame_size ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check( masked = true );
+       length : 7 : int;
+       mask : 32 : int;
+       payload : (length * 8) : string;
+       rest : -1 : bitstring |}
+      when length <= 125 && (max_frame_size == 0 || length <= max_frame_size) ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| _data : -1 : bitstring  |} ->
+        Some (`more (Bytestring.of_string data), "")
+
+  let serialize (t : t) =
+    let opcode, fin, compressed, mask, payload =
+      match t with
+      | Continuation { fin; compressed; payload } ->
+          (0x0, fin, compressed, new_mask (), payload)
+      | Text { fin; compressed; payload } ->
+          (0x1, fin, compressed, new_mask (), payload)
+      | Binary { fin; compressed; payload } ->
+          (0x2, fin, compressed, new_mask (), payload)
+      | Connection_close { fin; compressed; payload } ->
+          (0x8, fin, compressed, new_mask (), payload)
+      | Ping -> (0x9, true, false, new_mask (), "")
+      | Pong -> (0xA, true, false, new_mask (), "")
+    in
+    let bytes = String.to_bytes payload |> Bytes.length in
+
+    let encoded_payload_length = function
+      | () when bytes <= 125 -> {%bitstring| (bytes) : 7 ; (mask) : 32 |}
+      | () when bytes <= 65_535 ->
+          {%bitstring| 126 : 7; (bytes) : 16 ; (mask) : 32 |}
+      | () -> {%bitstring| 127 : 7; (Int64.of_int bytes) : 64 ; (mask) : 32 |}
+    in
+    let%bitstring header =
+      {| fin : 1; compressed : 1 ; 0x0 : 2; opcode : 4 ; 1 : 1 |}
+    in
+
+    let payload = unmask mask payload in
+    let payload = Bitstring.bitstring_of_string payload in
+
+    let data =
+      Bitstring.concat [ header; encoded_payload_length (); payload ]
+    in
+
+    let frame = Bitstring.string_of_bitstring data in
+    let bytestring = Bytestring.of_string frame in
+    bytestring
+end
+
+module Response = struct
+  let deserialize data =
+    let binstr = Bitstring.bitstring_of_string data in
+    match%bitstring binstr with
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check (masked = true);
+       pad2 : 7 : check( pad2 = 127 );
+       length : 64;
+       mask : 32;
+       payload : Int64.(mul length 8L |> to_int) : string;
+       rest : -1 : bitstring |}
+      ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check (masked = false);
+       pad2 : 7 : check( pad2 = 127 );
+       length : 64;
+       payload : Int64.(mul length 8L |> to_int) : string;
+       rest : -1 : bitstring |}
+      ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check (masked = true);
+       pad2 : 7 : check( pad2 = 126 );
+       length : 16 : int;
+       mask : 32 : int;
+       payload : (length * 8) : string;
+       rest : -1 : bitstring |}
+      ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check (masked = false);
+       pad2 : 7 : check( pad2 = 126 );
+       length : 16 : int;
+       payload : (length * 8) : string;
+       rest : -1 : bitstring |}
+      ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check (masked = true);
+       length : 7 : int;
+       mask : 32 : int;
+       payload : (length * 8) : string;
+       rest : -1 : bitstring |}
+      when length >= 0 && length <= 125 ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| fin : 1;
+       compressed : 1;
+       rsv : 2;
+       opcode : 4;
+       masked : 1 : check (masked = false);
+       length : 7 : int;
+       payload : (length * 8) : string;
+       rest : -1 : bitstring |}
+      when length >= 0 && length <= 125 ->
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| _data : -1 : bitstring  |} ->
+        Some (`more (Bytestring.of_string data), "")
+
+  let serialize (t : t) =
+    let compressed = false in
+    let opcode, fin, _compressed, payload =
+      match t with
+      | Continuation { fin; compressed; payload } ->
+          (0x0, fin, compressed, payload)
+      | Text { fin; compressed; payload } -> (0x1, fin, compressed, payload)
+      | Binary { fin; compressed; payload } -> (0x2, fin, compressed, payload)
+      | Connection_close { fin; compressed; payload } ->
+          (0x8, fin, compressed, payload)
+      | Ping -> (0x9, true, false, "")
+      | Pong -> (0xA, true, false, "")
+    in
+    let bytes = String.to_bytes payload |> Bytes.length in
+    trace (fun f -> f "payload has %d bytes" bytes);
+    let%bitstring header = {| fin : 1; compressed : 1; 0x0 : 2; opcode : 4|} in
+    let mask = function
+      | () when bytes <= 125 -> {%bitstring| 0 : 1; (bytes) : 7 |}
+      | () when bytes <= 65_535 -> {%bitstring| 0 : 1; 126 : 7; (bytes) : 16|}
+      | () -> {%bitstring| 0 : 1 ; 127 : 7; (Int64.of_int bytes) : 64 |}
+    in
+    let payload = Bitstring.bitstring_of_string payload in
+    let data = Bitstring.concat [ header; mask (); payload ] in
+    let frame = Bitstring.string_of_bitstring data in
+    let bytestring = Bytestring.of_string frame in
+    bytestring
+end

--- a/blink/websocket.ml
+++ b/blink/websocket.ml
@@ -53,11 +53,10 @@ let upgrade conn path =
 
 let send frames t =
   List.iter
-    (fun frame -> error (fun f -> f "sending frames: %a" Trail.Frame.pp frame))
+    (fun frame -> error (fun f -> f "sending frames: %a" Frame.pp frame))
     frames;
   let data =
-    Bytestring.concat Bytestring.empty
-      (List.map Trail.Frame.Request.serialize frames)
+    Bytestring.concat Bytestring.empty (List.map Frame.Request.serialize frames)
   in
   let* conn = Connection.send t.conn data in
   Ok { t with conn }
@@ -71,7 +70,7 @@ let receive { conn; buffer } =
 
   debug (fun f -> f "unfolding frames from: %S" (Bytestring.to_string data));
   let* frames, buffer =
-    Stream.unfold Trail.Frame.Response.deserialize (Bytestring.to_string data)
+    Stream.unfold Frame.Response.deserialize (Bytestring.to_string data)
     |> Stream.reduce_while (Ok ([], Bytestring.empty)) @@ fun frame state ->
        match (frame, state) with
        | `ok frame, Ok (acc, buff) -> `continue (Ok (frame :: acc, buff))

--- a/dune-project
+++ b/dune-project
@@ -19,10 +19,12 @@
  (synopsis "A short synopsis")
  (description "A longer description")
  (depends 
-   (trail (>= "0.0.1"))
    (angstrom (>= "0.15.0"))
    (castore (>= "0.0.2"))
-   (httpaf (>= "5.3.1"))
+   digestif
+   bitstring
+   httpaf 
+   ppx_bitstring
    (faraday (>= "0.8.2"))
    (http (>= "6.0.0~alpha2"))
    (mdx (and :with-test (>= "2.3.1")))

--- a/test/dune
+++ b/test/dune
@@ -8,7 +8,7 @@
  (modules blink_stream_test)
  (libraries blink))
 
-(test
- (name websocket_connect_test)
- (modules websocket_connect_test)
- (libraries blink))
+; (test
+;  (name websocket_connect_test)
+;  (modules websocket_connect_test)
+;  (libraries blink))

--- a/test/websocket_connect_test.ml
+++ b/test/websocket_connect_test.ml
@@ -35,12 +35,12 @@ let* conn = Blink.connect url in
 let* sock = Blink.WebSocket.upgrade conn "/ws" in
 (* $MDX part-end *)
 (* $MDX part-begin=stream *)
-let hello_world = Trail.Frame.text "hello world" in
+let hello_world = Blink.Frame.text "hello world" in
 
-Logger.info (fun f -> f "hello_world: %a" Trail.Frame.pp hello_world);
+Logger.info (fun f -> f "hello_world: %a" Blink.Frame.pp hello_world);
 
 let* sock = Blink.WebSocket.send [ hello_world ] sock in
 let* _sock, [ frame ] = Blink.WebSocket.receive sock in
-Logger.info (fun f -> f "got frame: %a" Trail.Frame.pp frame);
+Logger.info (fun f -> f "got frame: %a" Blink.Frame.pp frame);
 (* $MDX part-end *)
 Ok ()


### PR DESCRIPTION
I'm opening this one because I'm interested in experimenting with blink, but had to make some changes to the dependencies to get this one to compile. 

I'm interested in your feedback if this is the right direction to get blink working:

1. **Remove dependency on trail**: it had a transitive dependency on atacama v0.0.5, which does not seem to exist. It was only using `Frame.ml` from `trail`, which I've copied over (it could be moved to its own library and shared to avoid duplication)
2. **Add missing dependencies and remove unused ones**: digestif, bitstring, etc. were missing from the dune-project / opam file. `cohttp` was included but not used
3. **Fix versions on some dependencies**: the 5.3.1 version of `httpaf` was added, but I can't find a version higher than 0.7.1 in the official version or any obvious fork
4. **Disable websocket test**: this test seems to fail because its expecting a server to be running on :8080 - if its an example it probably should be moved to an examples folder

With these changes, I'm now able to get it compiling from scratch with a fresh switch using `opam switch create .`.